### PR TITLE
Improve isProcessRunning check

### DIFF
--- a/src/PHPDaemonizer/Daemon.php
+++ b/src/PHPDaemonizer/Daemon.php
@@ -283,7 +283,7 @@ class Daemon {
 
     private static function getPIDFileName() {
         $sSymbolicName = self::getCurrentScriptSymbolicName();
-        $sPIDFile = "/tmp/$sSymbolicName.pid";
+        $sPIDFile = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $sSymbolicName . ".pid";
         return $sPIDFile;
     }
 

--- a/src/PHPDaemonizer/Daemon.php
+++ b/src/PHPDaemonizer/Daemon.php
@@ -108,7 +108,16 @@ class Daemon {
     /* is process with given --process-number running (check it via PID file) */
 
     public static function isProcessRunning() {
-        return file_exists(self::getPIDFileName());
+        $sPIDFile = self::getPIDFileName();
+        if (file_exists($sPIDFile)) {
+            $iPid = file_get_contents($sPIDFile);
+            // special signal 0 - if posix_kill return true, this pid is running
+            if (posix_kill($iPid, 0)) {
+                return true;
+            }
+            self::removePIDFile();
+        }
+        return false;
     }
 
     /*  descructor to catch moment the daemon is shutting down


### PR DESCRIPTION
Current implementation Daemon::isProcessRunning has uncomfortable use case:
When daemon died unexpectedly and did not delete his PID-file for any reason, daemon no starts until PID-file is manually removed.

This pull request add check with special posix signal 0. From man page: 
> If sig is 0, then no signal is sent, but error checking is still performed; this can be used to check for the existence of a process ID or process group ID.

Also, i replace hardcoded /tmp to native sys_get_temp_dir() call.